### PR TITLE
Fix bug where cm.module is wrong and add dl button

### DIFF
--- a/block_material_download.php
+++ b/block_material_download.php
@@ -42,16 +42,7 @@ class block_material_download extends block_base {
 
         $modinfo = get_fast_modinfo($COURSE);
 
-        $meldung = <<<EOF
-<script type="text/javascript">
-function MM_jumpMenu(targ,selObj,restore){
-  eval(targ+".location='"+selObj.options[selObj.selectedIndex].value+"'");
-  if (restore) selObj.selectedIndex=0;
-}
-</script>
-EOF;
-?>
-        <?php
+        $meldung = '';
 
         foreach ($modinfo->instances as $modname => $instances) {
             if (array_key_exists($modname, $resources)) {
@@ -74,8 +65,9 @@ EOF;
 
         $downloadlink = array();
 
-        $sqlchk = "SELECT cm.id FROM {course_modules} cm WHERE cm.course = '" . $COURSE->id .
-                "' AND ( cm.module = 14 OR cm.module = 6 )";
+        $sqlchk = "SELECT cm.id FROM {course_modules} cm INNER JOIN {modules} m ON m.id = cm.module
+                 WHERE cm.course = '" . $COURSE->id .
+                "' AND ( m.name IN ('folder','resource') )";
         $modules = $DB->get_records_sql($sqlchk);
         foreach ($modules as $module) {
             $checkid = $module->id;
@@ -83,6 +75,7 @@ EOF;
                     "( cs.sequence LIKE ? OR cs.sequence LIKE ? OR cs.sequence LIKE ? OR cs.sequence = ? ) LIMIT 1";
             $rowsec = $DB->get_records_sql($sqlsec, array($COURSE->id, $checkid . ",%", '%,' . $checkid . ',%', '%,' .
                 $checkid, $checkid));
+
             foreach ($rowsec as $row) {
                 if (!empty($row->section)) {
                     $sectid = $row->section;
@@ -93,6 +86,8 @@ EOF;
 
         ksort($downloadlink);
         $showlink = '';
+        $this->content->footer = '';
+
         foreach ($downloadlink as $value => $text) {
             $optionprefix = get_string('resource2', 'block_material_download') . ' ' .
                 get_string('from', 'block_material_download') . ' ';
@@ -117,12 +112,16 @@ EOF;
                 $value . '">' . $optionprefix . $value . '</option>';
         }
         if ($meldung != '') {
-            $this->content->text = $meldung . '<br />';
-            $this->content->footer = '<form><select name="jumpMenu" id="jumpMenu" onchange="MM_jumpMenu(\'parent\',this,0)">' .
-                    '<option value="' . $CFG->wwwroot . $_SERVER['PHP_SELF'] . '?id=' . ($COURSE->id) . '">' .
-                    get_string('choose', 'block_material_download') . '</option><option value="' . $CFG->wwwroot .
-                    '/blocks/material_download/download_materialien.php?courseid=' . ($COURSE->id) . '&ccsectid=0">' .
-                    get_string('download_files', 'block_material_download') . '</option>' . $showlink . '</select></form>';
+            $this->content->text = $meldung;
+            $this->content->footer .= '
+                    <form onsubmit="this.action = document.getElementById(\'filename\').value">
+                        <select id="filename">
+                            <option value="#">' . get_string('choose', 'block_material_download') . '</option>
+                            ' . $showlink . '
+                            <option value="' . $CFG->wwwroot . '/blocks/material_download/download_materialien.php?courseid=' . ($COURSE->id) . '&ccsectid=0">' . get_string('download_files', 'block_material_download') . '</option>
+                        </select>
+                       <input type = "button" value = "' . get_string('download', 'moodle') . '" onclick="window.location.href=document.getElementById(\'filename\').value" />
+                   </form>';
         } else {
             $this->content->text = get_string('no_file_exist', 'block_material_download');
         }


### PR DESCRIPTION
I've made a change to the sqlcheck to find sections to generate zips from on all Moodle installs. The hardcoded cm.module ids don't work across all Moodle installs. 

I've also changed the jump menu to something more accessible. It's now a standard dropdown select and a download button. This fix also solves the problem where you click back on the "Please choose..." link after having downloaded something and get an error. 

I've also started investigating what would be involved in parsing through pages and labels for attached files. This is on the horizon for us. Thanks for the plugin!